### PR TITLE
Updated shca_stack.py to add ephemeral_storage_size to lambda 4

### DIFF
--- a/stack/shca_stack.py
+++ b/stack/shca_stack.py
@@ -41,6 +41,7 @@ from aws_cdk import CfnOutput
 from aws_cdk import Duration
 from aws_cdk import RemovalPolicy
 from aws_cdk import Stack
+from aws_cdk import Size
 from constructs import Construct
 import os
 
@@ -753,6 +754,7 @@ class ShcaStack(Stack):
             handler="lambda_function.lambda_handler",
             timeout=Duration.minutes(1),
             memory_size=2048,
+            ephemeral_storage_size=Size.gibibytes(2),
             # The following line is required to NeoLifter rule BC_AWS_GENERAL_65
             # "Ensure that AWS Lambda function is configured inside a VPC"
             vpc=self.vpc,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added import statement to import "Size" from "aws_cdk"
Added ephemeral_storage_size configuration to "create_4_package_artifacts"

This step needs to be adjusted in some environments depending on the size of the output files created by SHCA.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
