### PR TITLE
Make ephemeral storage configurable for package artifacts lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Modify the following values in `cdk.json`
     - "schedule_frequency_days": `7` - This setting dictates how often would you like SHCA to generate compliance reporting. 
     - "send_failure_notification_email": `true` or `false` - If `true`, email will be sent to the address provided in `failure_notification_email`.
     - "failure_notification_email": `example@email.com` - This email address will receive notifications upon a failure to execute SHCA.
+    - "package_artifacts_lambda_storage_size": `2048` - This setting dictates the ephemeral storage size in MB for the Package Artifacts lambda. Increase this if your reports are larger than 2048 MB. Specify a value between 512 MB and 10,240 MB, in 1-MB increments.
 
 From here you have two options on how to install SHCA (CloudShell or CDK)
 

--- a/cdk.json
+++ b/cdk.json
@@ -47,6 +47,7 @@
     "vpc_cidr": "10.30.0.0/24",
     "schedule_frequency_days": 1,
     "send_failure_notification_email": false,
-    "failure_notification_email": "youremail@yourdomain.com"
+    "failure_notification_email": "youremail@yourdomain.com",
+    "package_artifacts_lambda_storage_size": "2048"
   }
 }

--- a/stack/shca_stack.py
+++ b/stack/shca_stack.py
@@ -89,6 +89,10 @@ class ShcaStack(Stack):
             "openscap_amazonlinux_image_version_hash"
         )
 
+        self.package_artifacts_lambda_storage_size = self.node.try_get_context(
+            "package_artifacts_lambda_storage_size"
+        )
+
         # Function calls to create resources
         self.__create_kms_key()
         self.__create_vpc_flow_log_group()
@@ -749,7 +753,7 @@ class ShcaStack(Stack):
             handler="lambda_function.lambda_handler",
             timeout=Duration.minutes(1),
             memory_size=2048,
-            ephemeral_storage_size=Size.gibibytes(2),
+            ephemeral_storage_size=Size.mebibytes(int(self.package_artifacts_lambda_storage_size)),
             # The following line is required to NeoLifter rule BC_AWS_GENERAL_65
             # "Ensure that AWS Lambda function is configured inside a VPC"
             vpc=self.vpc,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The default Package Artifacts lambda ephemeral storage size sometimes does not accommodate the size of the zip file created. This change modifies `shca_stack.py` and `cdk.json` to accept a parameterized input in MB. Documentation is provided to explain this parameter to users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
