### PR TITLE
Fix unexpected zip downloads and improve file exclusion

### DIFF
--- a/requirements-deploy.txt
+++ b/requirements-deploy.txt
@@ -1,4 +1,4 @@
 aws-cdk-lib
 constructs>=10.0.0,<11.0.0
 cdk_nag
-cdk-ecr-deployment==2.5.37 # Later versions fail due to change in Lambda Runtime that likely isn't supported in GovCloud yet.
+#cdk-ecr-deployment==2.5.37 # Later versions fail due to change in Lambda Runtime that likely isn't supported in GovCloud yet.


### PR DESCRIPTION
- Add fnmatch import for improved file pattern matching
- Update exclude_prefixes to explicitly exclude all zip files
- Refactor download_s3_files function to use fnmatch for exclusions
- Improve logging for skipped files
- Removed duplicate import of tempfile
- Commented out cdk-ecr-deployment==2.5.37 in requirements.txt

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
