### PR TITLE
Refine S3 lifecycle rules for artifact retention

### DIFF
--- a/assets/lambda/code/4-package-artifacts/lambda_function.py
+++ b/assets/lambda/code/4-package-artifacts/lambda_function.py
@@ -113,7 +113,7 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
                     )
             # Zipping artifacts
             logger.info("Zipping files and directories to create artifacts zip")
-            artifacts_zip_path = os.path.join(tmp_dir, f"artifacts_{timestamp}.zip")
+            artifacts_zip_path = "artifacts.zip"
             with zipfile.ZipFile(artifacts_zip_path, "w") as zipf:
                 for root, dirs, files in os.walk(tmp_dir):
                     for file in files:
@@ -126,11 +126,11 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
             logger.info("Uploading zip file to s3")
 
             # Extract the file name from the artifacts_zip_path
-            zip_file_name_with_timestamp = os.path.basename(artifacts_zip_path)
+            zip_file_name = "artifacts.zip"
 
             # Define the S3 object name with the correct path and
             # the dynamically generated file name
-            s3_object_name = f"shca/{zip_file_name_with_timestamp}"
+            s3_object_name = f"shca/{zip_file_name}"
 
             upload_to_s3(artifacts_zip_path, bucket_name, s3_object_name)
 
@@ -138,12 +138,12 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
             print(
                 (
                     "Artifacts created and zipped successfully as ",
-                    f"{zip_file_name_with_timestamp}. Status code: 200",
+                    f"{zip_file_name}. Status code: 200",
                 )
             )
             return {
                 "message": "Artifacts created and zipped successfully"
-                f" as {zip_file_name_with_timestamp}."
+                f" as {zip_file_name}."
             }
 
     finally:
@@ -153,7 +153,7 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
         )
 
     return {
-        "message": f"Artifacts created and zipped successfully as artifacts_{timestamp}.zip",
+        "message": f"Artifacts created and zipped successfully as artifacts.zip",
         "max_used_storage_mb": max_used_storage_mb,
         "max_memory_allocated_mb": context.memory_limit_in_mb,
     }

--- a/assets/lambda/code/4-package-artifacts/lambda_function.py
+++ b/assets/lambda/code/4-package-artifacts/lambda_function.py
@@ -113,8 +113,8 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
                     )
             # Zipping artifacts
             logger.info("Zipping files and directories to create artifacts zip")
-            artifacts_zip_path = "artifacts.zip"
-            with zipfile.ZipFile(artifacts_zip_path, "w") as zipf:
+            zip_file_name = os.path.join(tmp_dir, "artifacts.zip")
+            with zipfile.ZipFile(zip_file_name, "w") as zipf:
                 for root, dirs, files in os.walk(tmp_dir):
                     for file in files:
                         file_path = os.path.join(root, file)
@@ -126,24 +126,23 @@ def lambda_handler(event, context):  # pylint: disable=unused-argument
             logger.info("Uploading zip file to s3")
 
             # Extract the file name from the artifacts_zip_path
-            zip_file_name = "artifacts.zip"
-
+            zip_file_name = os.path.join(tmp_dir, "artifacts.zip")
             # Define the S3 object name with the correct path and
             # the dynamically generated file name
-            s3_object_name = f"shca/{zip_file_name}"
+            s3_object_name = "shca/artifacts.zip"
 
-            upload_to_s3(artifacts_zip_path, bucket_name, s3_object_name)
+            upload_to_s3(zip_file_name, bucket_name, s3_object_name)
 
             log_disk_usage("before final clear")
             print(
                 (
                     "Artifacts created and zipped successfully as ",
-                    f"{zip_file_name}. Status code: 200",
+                    f"{os.path.basename(zip_file_name)}. Status code: 200",
                 )
             )
             return {
                 "message": "Artifacts created and zipped successfully"
-                f" as {zip_file_name}."
+                f" as {os.path.basename(zip_file_name)}."
             }
 
     finally:

--- a/cdk.json
+++ b/cdk.json
@@ -46,7 +46,8 @@
     "environment": "shca",
     "vpc_cidr": "10.30.0.0/24",
     "cidr_mask": 26,
-    "schedule_frequency_days": 1,
+    "schedule_frequency_days": 7,
+    "artifact_replicas_to_retain": 7,
     "send_failure_notification_email": false,
     "failure_notification_email": "youremail@yourdomain.com"
   }

--- a/stack/shca_stack.py
+++ b/stack/shca_stack.py
@@ -79,6 +79,10 @@ class ShcaStack(Stack):
             "schedule_frequency_days"
         )
 
+        self.artifact_replicas_to_retain = self.node.try_get_context(
+            "artifact_replicas_to_retain"
+        )
+
         self.send_failure_notification_email = self.node.try_get_context(
             "send_failure_notification_email"
         )
@@ -278,10 +282,10 @@ class ShcaStack(Stack):
 
         self.s3_resource_bucket.add_lifecycle_rule(
             enabled=True,
-            expiration=Duration.days(1825),
-            id="expire-1825-days",
-            noncurrent_versions_to_retain=3,
+            id="retain-artifact-replicas",
+            noncurrent_version_expiration=Duration.days(self.artifact_replicas_to_retain * 7),  # Assuming weekly backups
         )
+
 
         cdknag.NagSuppressions.add_resource_suppressions(
             construct=self.s3_resource_bucket,


### PR DESCRIPTION
 *Description of changes:*
- 4-package-artifacts/lambda_function.py:
  - Fixed zip_file_name type which caused Read-only file system when creating artifacts.zip

- shca_stack.py:
  - Removed expiration rule for current versions of S3 objects
  - Updated lifecycle rule to focus on noncurrent version management
  - implemented noncurrent_version_expiration using artifact_replicas_to_retain setting in cdk.json

- cdk.json:
  - Added artifact_replicas_to_retain configuration

This commit enhances the management of artifacts in the S3 bucket:
1. Current versions of objects will no longer expire automatically
2. Noncurrent (older) versions are managed based on the configurable artifact_replicas_to_retain value in cdk.json
3. The retention period for noncurrent versions is calculated assuming weekly backups (artifact_replicas_to_retain * 7 days)

These changes provide more flexible and precise control over artifact retention, allowing for long-term storage of current versions while efficiently managing historical data.





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
