### PR TITLE
Adds several minor updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ pip3 --version
 virtualenv --version
 ```
 
-#### wget (optional for update_aws_wrangler.sh)
+#### wget (if using `update_aws_wrangler.sh` script to download AWS Wrangler)
 
 ```bash
 wget --version
 ```
 
-#### jq (optional for update_aws_wrangler.sh)
+#### jq (if using `update_aws_wrangler.sh` script to download AWS Wrangler)
 
 ```bash
 jq --version


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Minor edits to `README.md` for better clarity
2. Removes outbound rules from VPC Endpoint security group, as they are not required
3. Scoping down outbound rules for Lambda function security group:
    1.  Removes the rule that allows all traffic
    2. Adds a rule to allow 443 traffic to S3 managed prefix list
    3. Adds a rule to allow 443 traffic to VPC CIDR for VPC endpoints
4. Creates an email subscription conditionally based on a context value ("send_failure_notification_email")
5. Adds a missing permission (`securityhub:DescribeStandardsControls`) that was causing an error in Config-Rules-Scrape Lambda function towards the end of execution (though the task itself succeeds)

*Testing:*

State machine executed all tasks successfully, generating the expected artifacts in the S3 bucket

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
