### PR TITLE
Fix deployment bugs: undefined account variable and missing region setup

### DIFF
--- a/cloud_shell_deployment.sh
+++ b/cloud_shell_deployment.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+AWS_REGION=$(aws configure get region)
+export CDK_DEFAULT_ACCOUNT=$AWS_ACCOUNT_ID
+export CDK_DEFAULT_REGION=$AWS_REGION
 echo "$AWS_ACCOUNT_ID"
 echo "$AWS_REGION"
 echo "aws://$AWS_ACCOUNT_ID/$AWS_REGION"

--- a/stack/shca_stack.py
+++ b/stack/shca_stack.py
@@ -63,7 +63,7 @@ class ShcaStack(Stack):
 
         # pylint: disable=line-too-long
         # fmt: off
-        self.aws_wrangler_layer = "assets/lambda/layers/awswrangler/awswrangler-layer-3.8.0-py3.11.zip"
+        self.aws_wrangler_layer = "assets/lambda/layers/awswrangler/awswrangler-layer-3.13.0-py3.11.zip"
 
         # Set variables from cdk context
         self.stack_env = self.node.try_get_context("environment")
@@ -98,6 +98,9 @@ class ShcaStack(Stack):
         self.openscap_amazonlinux_image_version_hash = self.node.try_get_context(
             "openscap_amazonlinux_image_version_hash"
         )
+
+        # Set account ID from CDK Stack property
+        self.account_id = self.account
 
         # Function calls to create resources
         self.__create_kms_key()
@@ -262,7 +265,7 @@ class ShcaStack(Stack):
         self.s3_resource_bucket = s3.Bucket(
             self,
             self.stack_env + "-resources",
-            bucket_name=self.stack_env + "-resources-" + self.account,
+            bucket_name=self.stack_env + "-resources-" + self.account_id,
             encryption=s3.BucketEncryption.KMS,
             bucket_key_enabled=True,
             encryption_key=self.kms_key,


### PR DESCRIPTION
- Fix undefined self.account variable in S3 bucket creation
- Add proper AWS region detection in cloud_shell_deployment.sh
- Export CDK environment variables for bootstrap command

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
